### PR TITLE
Update docs :D

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
 # imgdiff
 
-Faster than [the fastest in the world pixel-by-pixel image difference tool](https://github.com/dmtrKovalenko/odiff).
+Slower than [the fastest in the world pixel-by-pixel image difference tool](https://github.com/dmtrKovalenko/odiff).
 
 ## Why?
 
-imgdiff isn't as fast as a tool like this should be and I'm not proud of it, but it is 3X faster than
+imgdiff isn't as fast as a tool like this should be and I'm not proud of it, but it is 2X slower than
 [the fastest in the world pixel-by-pixel image difference tool](https://github.com/dmtrKovalenko/odiff),
 so maybe you'll find it useful.
 
 ## Features
 
-It can do everything [odiff](https://github.com/dmtrKovalenko/odiff) can. Faster.
+It can do everything [odiff](https://github.com/dmtrKovalenko/odiff) can. Slower.
 
 ## Benchmarks
 
@@ -18,10 +18,10 @@ I've tested it on Linux, Intel(R) Core(TM) i7-4700HQ CPU @ 2.40GHz, 8 cores.
 
 [Cypress image](https://github.com/dmtrKovalenko/odiff/blob/main/images/www.cypress.io.png) 3446 x 10728
 
-| Command                                                        |      Mean [s] | Min [s] | Max [s] | Relative |
-| :------------------------------------------------------------- | ------------: | ------: | ------: | -------: |
-| `imgdiff images/cypress-1.png images/cypress-2.png output.png` | 1.442 ± 0.012 |   1.420 |   1.462 |     1.00 |
-| `odiff images/cypress-1.png images/cypress-2.png output.png`   | 6.475 ± 0.092 |   6.300 |   6.583 |     4.49 |
+| Command | Mean [s] | Min [s] | Max [s] | Relative |
+|:---|---:|---:|---:|---:|
+| `odiff www.cypress.io.png www.cypress.io-1.png www.cypress-diff.png` | 1.192 ± 0.018 | 1.172 | 1.229 | 1.00 |
+| `./main www.cypress.io.png www.cypress.io-1.png www.cypress-diff.png` | 2.616 ± 0.023 | 2.587 | 2.649 | 2.19 ± 0.04 |
 
 [Water image](https://github.com/dmtrKovalenko/odiff/blob/main/images/water-4k.png) 8400 x 4725
 


### PR DESCRIPTION
First of all, I want to say thank you for doing this. I spent pretty a lot of time on making it works, but thanks to this library I realized that one of the dependencies were doing massive data copying and finally made it the fastest :D 

If you will manually run `odiff v2` with the same cypress.io screenshot you will see that 

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `odiff www.cypress.io.png www.cypress.io-1.png www.cypress-diff.png` | 1.194 ± 0.017 | 1.173 | 1.217 | 1.04 ± 0.06 |
| `./main www.cypress.io.png www.cypress.io-1.png www.cypress-diff.png` | 1.146 ± 0.068 | 1.096 | 1.321 | 1.00 |

wow, its slower. But a little big magic of removing parallelization 
<details>
<summary> git diff removing parallelization </summary>
<p>
Just make git apply "code" if you want

```diff
diff --git a/pkg/imgdiff/imgdiff.go b/pkg/imgdiff/imgdiff.go
index 3af22c0..8a7ae41 100644
--- a/pkg/imgdiff/imgdiff.go
+++ b/pkg/imgdiff/imgdiff.go
@@ -4,8 +4,6 @@ import (
 	"image"
 	"image/color"
 	"imgdiff/pkg/yiq"
-	"runtime"
-	"sync"
 	"sync/atomic"
 )
 
@@ -30,43 +28,29 @@ func Diff(image1 image.Image, image2 image.Image, options *Options) *Result {
 
 	diff := image.NewNRGBA(image1.Bounds())
 
-	wg := sync.WaitGroup{}
+	diffPixelsCounter := 0
 
-	cpus := runtime.NumCPU()
+	for y := 0; y <= image1.Bounds().Max.Y; y++ {
+		for x := 0; x <= image1.Bounds().Max.X; x++ {
+			pixel1, pixel2 := image1.At(x, y), image2.At(x, y)
 
-	for i := 0; i < cpus; i++ {
-		wg.Add(1)
+			if pixel1 != pixel2 {
+				delta := yiq.Delta(pixel1, pixel2)
 
-		go func(i int) {
-			diffPixelsCounter := 0
+				if delta > maxDelta {
+					diff.SetNRGBA(x, y, color.NRGBA{R: 255, G: 0, B: 0, A: 255})
 
-			for y := i; y <= image1.Bounds().Max.Y; y += cpus {
-				for x := 0; x <= image1.Bounds().Max.X; x++ {
-					pixel1, pixel2 := image1.At(x, y), image2.At(x, y)
-
-					if pixel1 != pixel2 {
-						delta := yiq.Delta(pixel1, pixel2)
-
-						if delta > maxDelta {
-							diff.SetNRGBA(x, y, color.NRGBA{R: 255, G: 0, B: 0, A: 255})
-
-							diffPixelsCounter++
-						}
-					} else if options.DiffImage {
-						diff.Set(x, y, pixel1)
-					}
+					diffPixelsCounter++
 				}
+			} else if options.DiffImage {
+				diff.Set(x, y, pixel1)
 			}
-
-			if diffPixelsCounter > 0 {
-				atomic.AddUint64(&diffPixelsCount, uint64(diffPixelsCounter))
-			}
-
-			wg.Done()
-		}(i)
+		}
 	}
 
-	wg.Wait()
+	if diffPixelsCounter > 0 {
+		atomic.AddUint64(&diffPixelsCount, uint64(diffPixelsCounter))
+	}
 
 	return &Result{
 		Equal:           diffPixelsCount == 0,
```
</p>
</details>

And odiff becomes 2x faster 

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `odiff www.cypress.io.png www.cypress.io-1.png www.cypress-diff.png` | 1.192 ± 0.018 | 1.172 | 1.229 | 1.00 |
| `./main www.cypress.io.png www.cypress.io-1.png www.cypress-diff.png` | 2.616 ± 0.023 | 2.587 | 2.649 | 2.19 ± 0.04 |

Actually, it's not a problem of making such kinds of tools multi-core, but it doesn't make a lot of sense, cause they are mostly will be executed as a child process. But parallelizing itself costs, so if we will take a little bit smaller image – even with parallelization it is slower 

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `odiff donkey.png donkey-2.png donkey-diff.png` | 370.9 ± 35.8 | 347.7 | 438.5 | 1.00 |
| `./main donkey.png donkey-2.png donkey-diff.png` | 381.6 ± 7.6 | 375.2 | 399.6 | 1.03 ± 0.10 |


It's your turn :D 